### PR TITLE
Use explicit branch for new version tag

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: false
+          release_branches: master
 
 
   build-and-publish-package:


### PR DESCRIPTION
* to make renaming the default branch easier