### PR TITLE
fix: echo new tags to the right VERSION file

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -60,9 +60,9 @@ jobs:
     - name: Install wheel package
       run: |
         pip install wheel
-    - name: Generate correct value for version.py file
+    - name: Generate correct value for VERSION file
       run: |
-        echo ${{ needs.tag-new-version.outputs.tag }} > VERSION
+        echo ${{ needs.tag-new-version.outputs.tag }} > osmatching/VERSION
     - name: Build package
       run: |
         python setup.py sdist bdist_wheel


### PR DESCRIPTION
We now have the right pypi setup, but we were writing to the wrong VERSION file, so the previous [run of the action](https://github.com/opensafely-core/matching/actions/runs/15583340317/job/43883566680) tagged correctly, but published version 0.2.0 because we hadn't updated the VERSION file in osmatching/VERSION