### PR TITLE
Validate config and input datasets before doing any matching calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ When using for example a general population control, the match patients may not 
   - `direction` is `earlier` or `later`
   - For example: `1_year_earlier`.
 
+Note: if the matches dataset does not have a column with the `index_date_variable` name, it will be
+created, and populated with the date generated from the matched case. If the matches dataset does have
+an `index_date_variable` column, it will be overwritten in the output dataset.
 
 `indicator_variable_name` (default: `"case"`)\
 A binary variable (`0` or `1`) is included in the output data to indicate whether each patient is a "case" or "match". The default is set to fit the nomenclature of a case control study, but this might be changed to for example `"exposed"` to fit better with a cohort study.

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ A Python dictionary containing a list of date variables (as keys) to use to excl
 `min_matches_per_case` (default: 0)\
 An integer that determines the minimum number of acceptable matches for each case. Sets of cases and matches where there are fewer than the specified number are dropped from the output data.
 
-`replace_match_index_date_with_case` (default: `""`)\
-When using for example a general population control, the match patients may not have an index date - meaning you want to pass the date from the case/exposed patient. This can be:
+`generate_match_index_date` (default: `""`)\
+When using for example a general population control, the match patients may not have an index date - meaning you want to generate the date for the matched patient from the case/exposed patient. This can be:
 - the exact same date as the case - specified by `"no_offset"`
 - with an offset in the format: `"n_unit_direction"`, where:
   - `n` is an integer number
@@ -297,7 +297,7 @@ match(
             index_date_variable="indexdate",
             closest_match_variables=["age"],
             min_matches_per_case=1,
-            replace_match_index_date_with_case="1_year_earlier",
+            generate_match_index_date="1_year_earlier",
             date_exclusion_variables={
                 "died_date_ons": "before",
                 "previous_vte_gp": "before",
@@ -338,7 +338,7 @@ match(
                 "stp": "category",
             },
             closest_match_variables=["age"],
-            replace_match_index_date_with_case="no_offset",
+            generate_match_index_date="no_offset",
             index_date_variable="indexdate",
             date_exclusion_variables={
                 "died_date_ons": "before",

--- a/osmatching/__main__.py
+++ b/osmatching/__main__.py
@@ -6,7 +6,13 @@ import sys
 from pathlib import Path
 
 from osmatching.osmatching import match
-from osmatching.utils import MatchConfig, file_suffix, load_config, load_dataframe
+from osmatching.utils import (
+    MatchConfig,
+    file_suffix,
+    load_config,
+    load_dataframe,
+    report_config_errors,
+)
 
 
 class LoadMatchingConfig(argparse.Action):
@@ -24,12 +30,7 @@ class LoadMatchingConfig(argparse.Action):
 
         config, errors = load_config(config)
         if errors:
-            print("\nErrors were found in the provided configuration:")
-            for key, errorlist in errors.items():
-                print(f"\n  {key}")
-                for error in errorlist:
-                    print(f"  * {error}")
-            print("\nPlease correct these errors and try again")
+            report_config_errors(errors)
             sys.exit(2)
         setattr(namespace, self.dest, config)
 

--- a/osmatching/__main__.py
+++ b/osmatching/__main__.py
@@ -11,8 +11,9 @@ from osmatching.utils import (
     file_suffix,
     load_config,
     load_dataframe,
-    report_config_errors,
+    report_validation_errors,
 )
+from osmatching.validation import ValidationType
 
 
 class LoadMatchingConfig(argparse.Action):
@@ -30,7 +31,7 @@ class LoadMatchingConfig(argparse.Action):
 
         config, errors = load_config(config)
         if errors:
-            report_config_errors(errors)
+            report_validation_errors(errors, validation_type=ValidationType.CONFIG)
             sys.exit(2)
         setattr(namespace, self.dest, config)
 

--- a/osmatching/__main__.py
+++ b/osmatching/__main__.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 from osmatching.osmatching import match
@@ -21,7 +22,15 @@ class LoadMatchingConfig(argparse.Action):
         except json.JSONDecodeError as exc:
             raise argparse.ArgumentTypeError(f"Could not parse {values}\n{exc}")
 
-        config = load_config(config)
+        config, errors = load_config(config)
+        if errors:
+            print("\nErrors were found in the provided configuration:")
+            for key, errorlist in errors.items():
+                print(f"\n  {key}")
+                for error in errorlist:
+                    print(f"  * {error}")
+            print("\nPlease correct these errors and try again")
+            sys.exit(2)
         setattr(namespace, self.dest, config)
 
 

--- a/osmatching/osmatching.py
+++ b/osmatching/osmatching.py
@@ -148,14 +148,14 @@ def date_exclusions(df1: pd.DataFrame, date_exclusion_variables: dict, index_dat
     """
     exclusions = pd.Series(data=False, index=df1.index)
     for exclusion_var, before_after in date_exclusion_variables.items():
-        if before_after == "before":
-            variable_bool = df1[exclusion_var] < index_date
-        elif before_after == "after":
-            variable_bool = df1[exclusion_var] > index_date
-        else:
-            raise Exception(
-                f"Date exclusion type '{before_after}' for variable '{exclusion_var}' invalid"
-            )
+        match before_after:
+            case "before":
+                variable_bool = df1[exclusion_var] < index_date
+            case "after":
+                variable_bool = df1[exclusion_var] > index_date
+            case _:  # pragma: no cover
+                # This should be caught in config validation so we should never get here
+                assert False, "Invalid date exclusion type"
         exclusions = exclusions | variable_bool
     return exclusions
 

--- a/osmatching/osmatching.py
+++ b/osmatching/osmatching.py
@@ -181,6 +181,8 @@ def greedily_pick_matches(
     specified). If there are more than matches_per_case matches who are identical,
     matches are randomly sampled.
     """
+    # Ensure we're working with a copy of the matched_rows df
+    matched_rows = matched_rows.copy()
     if closest_match_variables:
         sort_cols: list = []
         for var in closest_match_variables:
@@ -397,7 +399,9 @@ def match(
     write_output_file(
         matched_matches, match_config.output_path / f"matched_matches{file_suffix_ext}"
     )
-    combined = pd.concat([matched_cases, matched_matches])
+    combined = pd.concat(
+        [df for df in [matched_cases, matched_matches] if not df.empty]
+    )
     write_output_file(
         combined, match_config.output_path / f"matched_combined{file_suffix_ext}"
     )

--- a/osmatching/osmatching.py
+++ b/osmatching/osmatching.py
@@ -185,7 +185,7 @@ def greedily_pick_matches(
 
 def get_date_offset(offset_str: str) -> Optional[pd.DataFrame]:
     """
-    Parses the string given by replace_match_index_date_with_case
+    Parses the string given by generate_match_index_date
     to determine the unit and length of offset.
     Returns a pr.DateOffset of the appropriate length.
     """
@@ -281,8 +281,8 @@ def match(
     indices = pre_calculate_indices(cases, matches, match_config.match_variables)
     matching_report([f"Completed pre-calculating indices at {datetime.now()}"])
 
-    if match_config.replace_match_index_date_with_case:
-        offset_str = match_config.replace_match_index_date_with_case
+    if match_config.generate_match_index_date:
+        offset_str = match_config.generate_match_index_date
         date_offset = get_date_offset(offset_str)
 
     if match_config.date_exclusion_variables:
@@ -312,7 +312,7 @@ def match(
         matched_rows = matches.loc[eligible_matches]
 
         ## Determine match index date
-        if not match_config.replace_match_index_date_with_case:
+        if not match_config.generate_match_index_date:
             index_date = matched_rows[match_config.index_date_variable]
         else:
             if offset_str == "no_offset":
@@ -347,7 +347,7 @@ def match(
             matches.loc[matched_rows, "set_id"] = case_id
 
         ## Set index_date of the match where needed
-        if match_config.replace_match_index_date_with_case:
+        if match_config.generate_match_index_date:
             matches.loc[matched_rows, match_config.index_date_variable] = index_date
 
     ## Drop unmatched cases/matches

--- a/osmatching/osmatching.py
+++ b/osmatching/osmatching.py
@@ -2,7 +2,6 @@
 
 import copy
 from datetime import datetime
-from pathlib import Path
 from typing import Optional
 
 import pandas as pd
@@ -229,11 +228,12 @@ def match(
     if match_config.min_matches_per_case > match_config.matches_per_case:
         raise ValueError("min_matches_per_case cannot be greater than matches_per_case")
 
-    # Make sure the output path is a Path and it exists
-    output_path = Path(match_config.output_path)
-    output_path.mkdir(parents=True, exist_ok=True)
+    # Make sure the output path exists
+    match_config.output_path.mkdir(parents=True, exist_ok=True)
 
-    report_path = output_path / f"matching_report{match_config.output_suffix}.txt"
+    report_path = (
+        match_config.output_path / f"matching_report{match_config.output_suffix}.txt"
+    )
 
     def matching_report(text_list: list, erase: bool = False) -> None:
         if erase and report_path.is_file():
@@ -380,12 +380,16 @@ def match(
 
     ## Write output files
     file_suffix_ext = f"{match_config.output_suffix}.{match_config.output_format}"
-    write_output_file(matched_cases, output_path / f"matched_cases{file_suffix_ext}")
     write_output_file(
-        matched_matches, output_path / f"matched_matches{file_suffix_ext}"
+        matched_cases, match_config.output_path / f"matched_cases{file_suffix_ext}"
+    )
+    write_output_file(
+        matched_matches, match_config.output_path / f"matched_matches{file_suffix_ext}"
     )
     combined = pd.concat([matched_cases, matched_matches])
-    write_output_file(combined, output_path / f"matched_combined{file_suffix_ext}")
+    write_output_file(
+        combined, match_config.output_path / f"matched_combined{file_suffix_ext}"
+    )
 
     # return the matched dataframes, for ease of testing
     return matched_cases, matched_matches

--- a/osmatching/osmatching.py
+++ b/osmatching/osmatching.py
@@ -21,6 +21,7 @@ def import_data(
     """
     Sets the correct data types for the matching variables.
     """
+    assert match_config.match_variables is not None  # guaranteed by validation
     match_variables = copy.deepcopy(match_config.match_variables)
     ## Set data types for matching variables
     month_only = []
@@ -223,6 +224,10 @@ def match(
         if errors:
             report_config_errors(errors)
             raise ValueError("There was an error in one or more config values")
+
+    # Guaranteed by validation; assert not None to satisfy mypy
+    assert match_config.match_variables is not None
+    assert match_config.matches_per_case is not None
 
     # Make sure the output path exists
     match_config.output_path.mkdir(parents=True, exist_ok=True)

--- a/osmatching/osmatching.py
+++ b/osmatching/osmatching.py
@@ -90,12 +90,10 @@ def get_bool_index(
     according to the matching specification.
     """
     if match_type == "category":
-        bool_index = matches[match_var] == value
-    elif isinstance(match_type, int):
-        bool_index = abs(matches[match_var] - value) <= match_type
+        return matches[match_var] == value
     else:
-        raise Exception(f"Matching type '{match_type}' not yet implemented")
-    return bool_index
+        assert isinstance(match_type, int), "Unknown matching type '{match_type}'"
+        return abs(matches[match_var] - value) <= match_type
 
 
 def pre_calculate_indices(

--- a/osmatching/osmatching.py
+++ b/osmatching/osmatching.py
@@ -7,7 +7,7 @@ from typing import Optional
 import pandas as pd
 
 from osmatching.utils import MatchConfig, report_config_errors, write_output_file
-from osmatching.validation import parse_and_validate_config
+from osmatching.validation import parse_and_validate_config, validate_input_data
 
 
 NOT_PREVIOUSLY_MATCHED = -9
@@ -224,6 +224,11 @@ def match(
         if errors:
             report_config_errors(errors)
             raise ValueError("There was an error in one or more config values")
+
+    errors = validate_input_data(case_df, match_df, match_config)
+    if errors:
+        report_config_errors(errors)
+        raise ValueError("Errors encountered in the input datasets")
 
     # Guaranteed by validation; assert not None to satisfy mypy
     assert match_config.match_variables is not None

--- a/osmatching/osmatching.py
+++ b/osmatching/osmatching.py
@@ -6,8 +6,12 @@ from typing import Optional
 
 import pandas as pd
 
-from osmatching.utils import MatchConfig, report_config_errors, write_output_file
-from osmatching.validation import parse_and_validate_config, validate_input_data
+from osmatching.utils import MatchConfig, report_validation_errors, write_output_file
+from osmatching.validation import (
+    ValidationType,
+    parse_and_validate_config,
+    validate_input_data,
+)
 
 
 NOT_PREVIOUSLY_MATCHED = -9
@@ -222,12 +226,12 @@ def match(
     if not match_config.validated:
         match_config, errors = parse_and_validate_config(match_config)
         if errors:
-            report_config_errors(errors)
+            report_validation_errors(errors, validation_type=ValidationType.CONFIG)
             raise ValueError("There was an error in one or more config values")
 
     errors = validate_input_data(case_df, match_df, match_config)
     if errors:
-        report_config_errors(errors)
+        report_validation_errors(errors, validation_type=ValidationType.DATA)
         raise ValueError("Errors encountered in the input datasets")
 
     # Guaranteed by validation; assert not None to satisfy mypy

--- a/osmatching/osmatching.py
+++ b/osmatching/osmatching.py
@@ -225,9 +225,6 @@ def match(
     - save the results in the specified output format
     """
 
-    if match_config.min_matches_per_case > match_config.matches_per_case:
-        raise ValueError("min_matches_per_case cannot be greater than matches_per_case")
-
     # Make sure the output path exists
     match_config.output_path.mkdir(parents=True, exist_ok=True)
 

--- a/osmatching/osmatching.py
+++ b/osmatching/osmatching.py
@@ -51,7 +51,11 @@ def import_data(
         cases[var] = pd.to_datetime(cases[var])
         matches[var] = pd.to_datetime(matches[var])
 
-    ## Format index date as date
+    # If there is no index_date_variable in the matches df, add an empty column for it
+    if match_config.index_date_variable not in matches.columns:
+        matches[match_config.index_date_variable] = ""
+
+    ## Format index dates as date
     cases[match_config.index_date_variable] = pd.to_datetime(
         cases[match_config.index_date_variable]
     )

--- a/osmatching/osmatching.py
+++ b/osmatching/osmatching.py
@@ -6,7 +6,8 @@ from typing import Optional
 
 import pandas as pd
 
-from osmatching.utils import MatchConfig, write_output_file
+from osmatching.utils import MatchConfig, report_config_errors, write_output_file
+from osmatching.validation import parse_and_validate_config
 
 
 NOT_PREVIOUSLY_MATCHED = -9
@@ -216,6 +217,12 @@ def match(
     - set the index date of the match as that of the case (where desired)
     - save the results in the specified output format
     """
+    # validate the config if we haven't already
+    if not match_config.validated:
+        match_config, errors = parse_and_validate_config(match_config)
+        if errors:
+            report_config_errors(errors)
+            raise ValueError("There was an error in one or more config values")
 
     # Make sure the output path exists
     match_config.output_path.mkdir(parents=True, exist_ok=True)

--- a/osmatching/utils.py
+++ b/osmatching/utils.py
@@ -15,7 +15,7 @@ class MatchConfig:
     closest_match_variables: list[str] = field(default_factory=list)
     date_exclusion_variables: dict[Any, Any] = field(default_factory=dict)
     min_matches_per_case: int = 0
-    replace_match_index_date_with_case: str = ""
+    generate_match_index_date: str = ""
     output_suffix: str = ""
     indicator_variable_name: str = "case"
     output_path: Path = Path("output")

--- a/osmatching/utils.py
+++ b/osmatching/utils.py
@@ -22,6 +22,7 @@ class MatchConfig:
     output_path: Path = Path("output")
     drop_cases_from_matches: bool = False
     output_format: str = "arrow"
+    validated: bool = False
 
     @classmethod
     def from_dict(cls, config_dict):

--- a/osmatching/utils.py
+++ b/osmatching/utils.py
@@ -36,6 +36,7 @@ class MatchConfig:
             date_exclusion_variables=date_exclusion_variables,
         )
 
+
 DATAFRAME_READER: dict[str, tuple] = {
     ".csv": ("read_csv", {"engine": "pyarrow"}),
     ".arrow": ("read_feather", {}),
@@ -53,7 +54,9 @@ def load_config(match_config: dict) -> MatchConfig:
             taken from json
 
     Returns:
-        MatchConfig: Configuration instance to be passed to entry point.
+        tuple of MatchConfig, errors (dict)
+        - MatchConfig: Configuration instance to be passed to entry point
+        - errors: a dict of MatchConfig fields tp validation errors
     """
     return parse_and_validate_config(MatchConfig.from_dict(match_config))
 

--- a/osmatching/utils.py
+++ b/osmatching/utils.py
@@ -16,6 +16,7 @@ class MatchConfig:
     date_exclusion_variables: dict[Any, Any] = field(default_factory=dict)
     min_matches_per_case: int = 0
     generate_match_index_date: str = ""
+    match_index_date_offset: tuple[str, str, int] | None = None
     output_suffix: str = ""
     indicator_variable_name: str = "case"
     output_path: Path = Path("output")

--- a/osmatching/utils.py
+++ b/osmatching/utils.py
@@ -4,6 +4,8 @@ from typing import Any
 
 import pandas as pd
 
+from osmatching.validation import parse_and_validate_config
+
 
 @dataclass
 class MatchConfig:
@@ -30,18 +32,17 @@ DATAFRAME_WRITER: dict[str, str] = {".csv": "to_csv", ".arrow": "to_feather"}
 
 def load_config(match_config: dict) -> MatchConfig:
     """
-    Takes in match configuration and changes these key-value pairs
-    where indicated by the match config. All other key-value pairs
-    are left as default values
+    Converts a match configuration dictionary to a MatchConfig
+    object.
 
     Args:
         match_config (dict): dictionary of the match configuration
             taken from json
 
     Returns:
-        dict (cfg): Configuration dictionary to be passed to entry point.
+        MatchConfig: Configuration instance to be passed to entry point.
     """
-    return MatchConfig(**match_config)
+    return parse_and_validate_config(MatchConfig(**match_config))
 
 
 def file_suffix(file_path: Path):

--- a/osmatching/utils.py
+++ b/osmatching/utils.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pandas as pd
 
-from osmatching.validation import parse_and_validate_config
+from osmatching.validation import ValidationType, parse_and_validate_config
 
 
 @dataclass
@@ -86,8 +86,8 @@ def write_output_file(df, file_path):
     writer(file_path)
 
 
-def report_config_errors(errors):
-    print("\nErrors were found in the provided configuration:")
+def report_validation_errors(errors: dict[str, list], validation_type: ValidationType):
+    print(f"\nErrors were found in the provided {validation_type.value}:")
     for key, errorlist in errors.items():
         print(f"\n  {key}")
         for error in errorlist:

--- a/osmatching/utils.py
+++ b/osmatching/utils.py
@@ -83,3 +83,12 @@ def write_output_file(df, file_path):
     # feather requires that we reset the index before writing
     writer = getattr(df.reset_index(), DATAFRAME_WRITER[suffix])
     writer(file_path)
+
+
+def report_config_errors(errors):
+    print("\nErrors were found in the provided configuration:")
+    for key, errorlist in errors.items():
+        print(f"\n  {key}")
+        for error in errorlist:
+            print(f"  * {error}")
+    print("\nPlease correct these errors and try again")

--- a/osmatching/utils.py
+++ b/osmatching/utils.py
@@ -9,9 +9,9 @@ from osmatching.validation import parse_and_validate_config
 
 @dataclass
 class MatchConfig:
-    matches_per_case: int
-    match_variables: dict
-    index_date_variable: str
+    matches_per_case: int | None = None
+    match_variables: dict | None = None
+    index_date_variable: str | None = None
     closest_match_variables: list[str] = field(default_factory=list)
     date_exclusion_variables: dict[Any, Any] = field(default_factory=dict)
     min_matches_per_case: int = 0
@@ -35,6 +35,10 @@ class MatchConfig:
             closest_match_variables=closest_match_variables,
             date_exclusion_variables=date_exclusion_variables,
         )
+
+    @staticmethod
+    def required_vars():
+        return ["matches_per_case", "match_variables", "index_date_variable"]
 
 
 DATAFRAME_READER: dict[str, tuple] = {

--- a/osmatching/utils.py
+++ b/osmatching/utils.py
@@ -18,10 +18,23 @@ class MatchConfig:
     replace_match_index_date_with_case: str = ""
     output_suffix: str = ""
     indicator_variable_name: str = "case"
-    output_path: str = "output"
+    output_path: Path = Path("output")
     drop_cases_from_matches: bool = False
     output_format: str = "arrow"
 
+    @classmethod
+    def from_dict(cls, config_dict):
+        output_path = Path(config_dict.pop("output_path", None) or "output")
+        closest_match_variables = config_dict.pop("closest_match_variables", None) or []
+        date_exclusion_variables = (
+            config_dict.pop("date_exclusion_variables", None) or {}
+        )
+        return cls(
+            **config_dict,
+            output_path=output_path,
+            closest_match_variables=closest_match_variables,
+            date_exclusion_variables=date_exclusion_variables,
+        )
 
 DATAFRAME_READER: dict[str, tuple] = {
     ".csv": ("read_csv", {"engine": "pyarrow"}),
@@ -42,7 +55,7 @@ def load_config(match_config: dict) -> MatchConfig:
     Returns:
         MatchConfig: Configuration instance to be passed to entry point.
     """
-    return parse_and_validate_config(MatchConfig(**match_config))
+    return parse_and_validate_config(MatchConfig.from_dict(match_config))
 
 
 def file_suffix(file_path: Path):

--- a/osmatching/validation.py
+++ b/osmatching/validation.py
@@ -8,10 +8,10 @@ import pandas as pd
 
 if TYPE_CHECKING:  # pragma: no cover
     # We are avoiding circular dependencies by using forward references for
-    # type annotations where necessary, and this check so that type-checkin
+    # type annotations where necessary, and this check so that type-checking
     # imports are not executed at runtime.
     # https://peps.python.org/pep-0484/#forward-references
-    # https://mypy.readthedocs.io/en/stable/runtime_troubles.html#import-cycles`
+    # https://mypy.readthedocs.io/en/stable/runtime_troubles.html#import-cycles
     from osmatching.utils import MatchConfig
 
 

--- a/osmatching/validation.py
+++ b/osmatching/validation.py
@@ -23,6 +23,12 @@ def replace_none_with_default(config, name, default):
         setattr(config, name, default)
 
 
+def validate_date_exclusions(date_exclusion_variables):
+    for exclusion_var, when in date_exclusion_variables.items():
+        if when not in ["before", "after"]:
+            yield exclusion_var, when
+
+
 def parse_and_validate_config(config: "MatchConfig"):
     """
     Validate config values where possible in advance of any calculations
@@ -47,5 +53,13 @@ def parse_and_validate_config(config: "MatchConfig"):
     # ensure we don't have None values where we expect empty lists/dicts
     replace_none_with_default(config, "closest_match_variables", [])
     replace_none_with_default(config, "date_exclusion_variables", {})
+
+    # validate date exclusion types
+    for exclusion_var, invalid_when in validate_date_exclusions(
+        config.date_exclusion_variables
+    ):
+        errors["date_exclusion_variables"].append(
+            f"Invalid exclusion type '{invalid_when}' for variable '{exclusion_var}'. Allowed types are 'before' or 'after'"
+        )
 
     return config, errors

--- a/osmatching/validation.py
+++ b/osmatching/validation.py
@@ -29,6 +29,21 @@ def validate_date_exclusions(date_exclusion_variables):
             yield exclusion_var, when
 
 
+def validate_match_variables(match_variables):
+    """
+    validate types for match variables - currently category or scalar (int) only
+    Note that month_only matches are converted to month categories
+    """
+    if match_variables is None:
+        return
+
+    for match_var, match_type in match_variables.items():
+        if match_type in ["category", "month_only"]:
+            continue
+        if not isinstance(match_type, int):
+            yield match_var, match_type
+
+
 def parse_and_validate_config(config: "MatchConfig"):
     """
     Validate config values where possible in advance of any calculations
@@ -60,6 +75,12 @@ def parse_and_validate_config(config: "MatchConfig"):
     ):
         errors["date_exclusion_variables"].append(
             f"Invalid exclusion type '{invalid_when}' for variable '{exclusion_var}'. Allowed types are 'before' or 'after'"
+        )
+
+    # Validate that match_variable are of allowed types
+    for match_var, invalid_type in validate_match_variables(config.match_variables):
+        errors["match_variables"].append(
+            f"Invalid match type '{invalid_type}' for variable `{match_var}`. Allowed are 'category', 'month_only', and integers."
         )
 
     return config, errors

--- a/osmatching/validation.py
+++ b/osmatching/validation.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    # We are avoiding circular dependencies by using forward references for
+    # type annotations where necessary, and this check so that type-checkin
+    # imports are not executed at runtime.
+    # https://peps.python.org/pep-0484/#forward-references
+    # https://mypy.readthedocs.io/en/stable/runtime_troubles.html#import-cycles`
+    from osmatching.utils import MatchConfig
+
+
+def parse_and_validate_config(config: "MatchConfig"):
+    """
+    Validate config values where possible in advance of any calculations
+    """
+    # ensure output_path is a Path
+    config.output_path = Path(config.output_path)
+
+    return config

--- a/osmatching/validation.py
+++ b/osmatching/validation.py
@@ -18,6 +18,11 @@ def validate_required_vars(config):
             yield var
 
 
+def replace_none_with_default(config, name, default):
+    if getattr(config, name) is None:
+        setattr(config, name, default)
+
+
 def parse_and_validate_config(config: "MatchConfig"):
     """
     Validate config values where possible in advance of any calculations
@@ -38,5 +43,9 @@ def parse_and_validate_config(config: "MatchConfig"):
         errors["min_matches_per_case"].append(
             f"`min_matches_per_case` ({config.min_matches_per_case}) cannot be greater than `matches_per_case` ({config.matches_per_case})"
         )
+
+    # ensure we don't have None values where we expect empty lists/dicts
+    replace_none_with_default(config, "closest_match_variables", [])
+    replace_none_with_default(config, "date_exclusion_variables", {})
 
     return config, errors

--- a/osmatching/validation.py
+++ b/osmatching/validation.py
@@ -12,6 +12,12 @@ if TYPE_CHECKING:  # pragma: no cover
     from osmatching.utils import MatchConfig
 
 
+def validate_required_vars(config):
+    for var in config.required_vars():
+        if getattr(config, var) is None:
+            yield var
+
+
 def parse_and_validate_config(config: "MatchConfig"):
     """
     Validate config values where possible in advance of any calculations
@@ -21,10 +27,16 @@ def parse_and_validate_config(config: "MatchConfig"):
 
     errors = defaultdict(list)
 
+    for missing in validate_required_vars(config):
+        errors[missing].append(f"Not found: `{missing}` is a required config variable")
+
     # validate min matches per case
-    if config.min_matches_per_case > config.matches_per_case:
+    if (
+        config.matches_per_case is not None
+        and config.min_matches_per_case > config.matches_per_case
+    ):
         errors["min_matches_per_case"].append(
-            f"min_matches_per_case ({config.min_matches_per_case}) cannot be greater than matches_per_case ({config.matches_per_case})"
+            f"`min_matches_per_case` ({config.min_matches_per_case}) cannot be greater than `matches_per_case` ({config.matches_per_case})"
         )
 
     return config, errors

--- a/osmatching/validation.py
+++ b/osmatching/validation.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -12,6 +13,11 @@ if TYPE_CHECKING:  # pragma: no cover
     # https://peps.python.org/pep-0484/#forward-references
     # https://mypy.readthedocs.io/en/stable/runtime_troubles.html#import-cycles`
     from osmatching.utils import MatchConfig
+
+
+class ValidationType(Enum):
+    CONFIG = "configuration"
+    DATA = "input data"
 
 
 def validate_required_vars(config):

--- a/osmatching/validation.py
+++ b/osmatching/validation.py
@@ -117,4 +117,9 @@ def parse_and_validate_config(config: "MatchConfig"):
     except ValueError as error:
         errors["generate_match_index_date"] = [str(error)]
 
+    # Flag this config as validated. We expect that match() will only be called from the
+    # command line, which will always call this method to parse and validate the provided config
+    # dict. However, in the event that the module is used from a shell, we may need to check
+    # that it has been validated and re-validate if necessary.
+    config.validated = True
     return config, errors

--- a/osmatching/validation.py
+++ b/osmatching/validation.py
@@ -18,4 +18,8 @@ def parse_and_validate_config(config: "MatchConfig"):
     # ensure output_path is a Path
     config.output_path = Path(config.output_path)
 
+    # validate min matches per case
+    if config.min_matches_per_case > config.matches_per_case:
+        raise ValueError("min_matches_per_case cannot be greater than matches_per_case")
+
     return config

--- a/osmatching/validation.py
+++ b/osmatching/validation.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -18,8 +19,12 @@ def parse_and_validate_config(config: "MatchConfig"):
     # ensure output_path is a Path
     config.output_path = Path(config.output_path)
 
+    errors = defaultdict(list)
+
     # validate min matches per case
     if config.min_matches_per_case > config.matches_per_case:
-        raise ValueError("min_matches_per_case cannot be greater than matches_per_case")
+        errors["min_matches_per_case"].append(
+            f"min_matches_per_case ({config.min_matches_per_case}) cannot be greater than matches_per_case ({config.matches_per_case})"
+        )
 
-    return config
+    return config, errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ show_missing = true
 exclude_also = [
   # this condition is only true when a module is run as a script
   'if __name__ == "__main__":',
+  # this indicates that the line should never be hit
+  "assert False.*",
 ]
 
 [tool.coverage.html]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -136,3 +136,37 @@ def test_config_bad_json():
 
     with pytest.raises(ArgumentTypeError, match="Could not parse {foo}"):
         main()
+
+
+def test_config_validation_errors(capsys):
+    sys.argv = [
+        "match",
+        "--cases",
+        str(FIXTURE_PATH / "input_cases.csv"),
+        "--controls",
+        str(FIXTURE_PATH / "input_controls.csv"),
+        "--config",
+        json.dumps(
+            {
+                "matches_per_case": 1,
+                "min_matches_per_case": 2,
+                "index_date_variable": "index_date",
+                "match_variables": {"age": 5},
+            }
+        ),
+    ]
+    with pytest.raises(SystemExit):
+        main()
+
+    output = capsys.readouterr().out
+    assert (
+        output
+        == """
+Errors were found in the provided configuration:
+
+  min_matches_per_case
+  * min_matches_per_case (2) cannot be greater than matches_per_case (1)
+
+Please correct these errors and try again
+"""
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -170,3 +170,37 @@ Errors were found in the provided configuration:
 Please correct these errors and try again
 """
     )
+
+
+def test_input_data_validation_errors(capsys):
+    sys.argv = [
+        "match",
+        "--cases",
+        str(FIXTURE_PATH / "input_cases.csv"),
+        "--controls",
+        str(FIXTURE_PATH / "input_controls.csv"),
+        "--config",
+        json.dumps(
+            {
+                "matches_per_case": 1,
+                "index_date_variable": "indexdate",
+                "match_variables": {"imd": 5},
+            }
+        ),
+    ]
+    with pytest.raises(ValueError):
+        main()
+
+    output = capsys.readouterr().out
+    assert (
+        output
+        == """
+Errors were found in the provided input data:
+
+  required_columns
+  * column(s) `imd` not found in cases dataset
+  * column(s) `imd` not found in matches dataset
+
+Please correct these errors and try again
+"""
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -165,7 +165,7 @@ def test_config_validation_errors(capsys):
 Errors were found in the provided configuration:
 
   min_matches_per_case
-  * min_matches_per_case (2) cannot be greater than matches_per_case (1)
+  * `min_matches_per_case` (2) cannot be greater than `matches_per_case` (1)
 
 Please correct these errors and try again
 """

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -128,27 +128,6 @@ def test_match_min_matches_per_case(tmp_path, min_per_case, match_count):
         assert len(matched_matches[matched_matches.set_id == set_id]) >= min_per_case
 
 
-def test_match_min_matches_per_case_cannot_be_less_than_matches_per_case(tmp_path):
-    """Test that match() runs and produces a matching report and outputs."""
-    test_matching = {
-        "matches_per_case": 1,
-        "min_matches_per_case": 2,
-        "match_variables": {
-            "sex": "category",
-        },
-        "index_date_variable": "indexdate",
-        "output_path": tmp_path,
-    }
-    with pytest.raises(
-        ValueError, match="min_matches_per_case cannot be greater than matches_per_case"
-    ):
-        match(
-            case_df=load_dataframe(FIXTURE_PATH / "input_cases.csv"),
-            match_df=load_dataframe(FIXTURE_PATH / "input_controls.csv"),
-            match_config=MatchConfig(**test_matching),
-        )
-
-
 def test_match_closest_match_variables_empty(tmp_path):
     """Test that match() runs and produces a matching report and outputs."""
     test_matching = {

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -215,7 +215,7 @@ def test_match_drop_cases(tmp_path, drop_cases_from_matches):
         ("2_years_earlier", datetime(2018, 7, 29)),
     ],
 )
-def test_replace_match_index_date_with_case(tmp_path, offset, expected_indexdate):
+def test_generate_match_index_date(tmp_path, offset, expected_indexdate):
     test_matching = {
         "matches_per_case": 1,
         "match_variables": {
@@ -228,7 +228,7 @@ def test_replace_match_index_date_with_case(tmp_path, offset, expected_indexdate
         "index_date_variable": "indexdate",
         "output_path": tmp_path,
         "drop_cases_from_matches": True,
-        "replace_match_index_date_with_case": offset,
+        "generate_match_index_date": offset,
     }
 
     case_df = load_dataframe(FIXTURE_PATH / "input_cases.csv")
@@ -242,7 +242,7 @@ def test_replace_match_index_date_with_case(tmp_path, offset, expected_indexdate
     assert matched_matches.iloc[0].indexdate == expected_indexdate
 
 
-def test_replace_match_index_date_offset_error(tmp_path):
+def test_generate_match_index_date_offset_error(tmp_path):
     test_matching = {
         "matches_per_case": 1,
         "match_variables": {
@@ -254,7 +254,7 @@ def test_replace_match_index_date_offset_error(tmp_path):
         "closest_match_variables": ["age"],
         "index_date_variable": "indexdate",
         "drop_cases_from_matches": True,
-        "replace_match_index_date_with_case": "1_day_before",
+        "generate_match_index_date": "1_day_before",
         "output_path": tmp_path,
     }
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -157,12 +157,12 @@ def test_match_closest_match_variables_empty(tmp_path):
     pd.testing.assert_frame_equal(matched_matches_1, matched_matches_2)
 
     test_matching.update({"closest_match_variables": None})
-    with pytest.raises(TypeError):
-        match(
-            case_df=load_dataframe(FIXTURE_PATH / "input_cases.csv"),
-            match_df=load_dataframe(FIXTURE_PATH / "input_controls.csv"),
-            match_config=MatchConfig(**test_matching),
-        )
+    # None values are converted to [] during validation
+    match(
+        case_df=load_dataframe(FIXTURE_PATH / "input_cases.csv"),
+        match_df=load_dataframe(FIXTURE_PATH / "input_controls.csv"),
+        match_config=MatchConfig(**test_matching),
+    )
 
 
 @pytest.mark.parametrize("drop_cases_from_matches", [True, False])
@@ -468,3 +468,16 @@ def test_get_date_offset():
     assert one_year_before == pd.DateOffset(years=1)
     assert two_months_before == pd.DateOffset(months=2)
     assert three_days_before == pd.DateOffset(days=3)
+
+
+def test_match_with_config_errors():
+    cases = pd.DataFrame.from_records(
+        [{"patient_id": 1, "age": 36, "index_date": "2024-01-01"}]
+    )
+    matches = pd.DataFrame.from_records(
+        [{"patient_id": 2, "age": 30, "index_date": "2024-02-01"}]
+    )
+    with pytest.raises(
+        ValueError, match="There was an error in one or more config values"
+    ):
+        match(cases, matches, MatchConfig())

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -302,17 +302,6 @@ def test_scalar_get_bool_index():
     assert bool_index.equals(pd.Series([False, True, True, False, False]))
 
 
-def test_get_bool_index_unknown_match_tupe():
-    match_type = "foo"
-    value = 36
-    match_var = "value"
-    matches = pd.DataFrame.from_records(
-        [[30], [36], [39], [61], [75]], columns=["value"]
-    )
-    with pytest.raises(Exception, match="Matching type 'foo' not yet implemented"):
-        get_bool_index(match_type, value, match_var, matches)
-
-
 def test_pre_calculate_indices():
     """
     Test that the test_data booleans match with a predetermined series for a simple

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -270,6 +270,40 @@ def test_generate_match_index_date_offset_error(tmp_path):
         )
 
 
+def test_no_control_index_date(tmp_path):
+    # If match input data has no index date variable, one is added
+    test_matching = {
+        "matches_per_case": 3,
+        "match_variables": {"sex": "category"},
+        "index_date_variable": "indexdate",
+        "output_path": tmp_path,
+        "generate_match_index_date": "no_offset",
+    }
+
+    case_df = pd.DataFrame.from_records(
+        [
+            [1, datetime(2021, 1, 1), "F"],
+            [2, datetime(2022, 2, 1), "M"],
+        ],
+        columns=["patient_id", "indexdate", "sex"],
+    )
+    match_df = pd.DataFrame.from_records(
+        [[4, "F"], [5, "M"], [6, "F"], [7, "M"], [8, "F"]],
+        columns=["patient_id", "sex"],
+    )
+    _, matched_matches = match(
+        case_df,
+        match_df,
+        match_config=MatchConfig(**test_matching),
+    )
+
+    # match index date is generated from the case
+    for f_index in [0, 2, 4]:
+        assert matched_matches.iloc[f_index].indexdate == datetime(2021, 1, 1)
+    for m_index in [1, 3]:
+        assert matched_matches.iloc[m_index].indexdate == datetime(2022, 2, 1)
+
+
 def test_categorical_get_bool_index():
     """
     Runs get_eligible_matches on synthetic categorical data and compares the test_data

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -430,25 +430,6 @@ def test_date_exclusions():
     assert excl_ser.equals(pd.Series([True, True, False, True, False, True]))
 
 
-def test_date_exclusions_invalid_type():
-    df1 = pd.DataFrame.from_records(
-        [
-            {"died_date": "2019-03-12"},
-        ]
-    )
-    df1["died_date"] = pd.to_datetime(df1["died_date"])
-    date_exclusion_variables = {
-        "died_date": "on_or_before",
-    }
-    index_date = "2020-02-01"
-
-    with pytest.raises(
-        Exception,
-        match="Date exclusion type 'on_or_before' for variable 'died_date' invalid",
-    ):
-        date_exclusions(df1, date_exclusion_variables, index_date)
-
-
 def test_greedily_pick_matches():
     """
     Runs greedily_pick_matches on synthetic data and compares the test_data with

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from osmatching.utils import MatchConfig
+import pytest
+
+from osmatching.utils import MatchConfig, parse_and_validate_config
 
 
 CONFIG_DICT_DEFAULTS = {
@@ -8,6 +10,11 @@ CONFIG_DICT_DEFAULTS = {
     "index_date_variable": "index_date",
     "match_variables": {"age": 5},
 }
+
+
+def get_match_config(test_config):
+    test_data = {**CONFIG_DICT_DEFAULTS, **test_config}
+    return MatchConfig(**test_data)
 
 
 def test_output_path():
@@ -21,3 +28,16 @@ def test_defaults():
     config = MatchConfig.from_dict(test_data)
     assert config.closest_match_variables == []
     assert config.date_exclusion_variables == {}
+
+
+@pytest.mark.parametrize("min_matches,error", [(0, False), (1, False), (2, True)])
+def test_min_matches_per_case(min_matches, error):
+    config = get_match_config({"min_matches_per_case": min_matches})
+    if error:
+        with pytest.raises(
+            ValueError,
+            match="min_matches_per_case cannot be greater than matches_per_case",
+        ):
+            parse_and_validate_config(config)
+    else:
+        parse_and_validate_config(config)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -81,3 +81,22 @@ def test_replace_none_with_default():
     assert errors == {}
     assert config.date_exclusion_variables == {}
     assert config.closest_match_variables == []
+
+
+def test_date_exclusions_invalid_type():
+    config = get_match_config(
+        {
+            "date_exclusion_variables": {
+                "died_date": "on_or_before",
+                "event_date": "on_or_after",
+                "hospitalisation_date": "before",
+            }
+        }
+    )
+    config, errors = parse_and_validate_config(config)
+    assert errors == {
+        "date_exclusion_variables": [
+            "Invalid exclusion type 'on_or_before' for variable 'died_date'. Allowed types are 'before' or 'after'",
+            "Invalid exclusion type 'on_or_after' for variable 'event_date'. Allowed types are 'before' or 'after'",
+        ]
+    }

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -21,6 +21,11 @@ def get_match_config(test_config):
 def test_output_path():
     config = get_match_config({"output_path": "test_output"})
     assert isinstance(config.output_path, Path)
+    assert not config.validated
+
+    config, errors = parse_and_validate_config(config)
+    assert config.validated
+    assert errors == {}
 
 
 def test_defaults():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from osmatching.utils import MatchConfig, parse_and_validate_config
+from osmatching.utils import MatchConfig
 
 
 CONFIG_DICT_DEFAULTS = {
@@ -12,8 +12,12 @@ CONFIG_DICT_DEFAULTS = {
 
 def test_output_path():
     test_data = {**CONFIG_DICT_DEFAULTS, "output_path": "test_output"}
-    config = MatchConfig(**test_data)
-    assert isinstance(config.output_path, str)
-
-    parse_and_validate_config(config)
+    config = MatchConfig.from_dict(test_data)
     assert isinstance(config.output_path, Path)
+
+
+def test_defaults():
+    test_data = {**CONFIG_DICT_DEFAULTS, "closest_match_variables": None}
+    config = MatchConfig.from_dict(test_data)
+    assert config.closest_match_variables == []
+    assert config.date_exclusion_variables == {}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -100,3 +100,27 @@ def test_date_exclusions_invalid_type():
             "Invalid exclusion type 'on_or_after' for variable 'event_date'. Allowed types are 'before' or 'after'",
         ]
     }
+
+
+def test_match_variables_types():
+    config = get_match_config(
+        {
+            "match_variables": {
+                "died_date": "month_only",
+                "age": 5,
+                "sex": "category",
+                "negative": -4,
+                "region": "London",
+                "score": 1.5,
+                "none": None,
+            }
+        }
+    )
+    config, errors = parse_and_validate_config(config)
+    assert errors == {
+        "match_variables": [
+            "Invalid match type 'London' for variable `region`. Allowed are 'category', 'month_only', and integers.",
+            "Invalid match type '1.5' for variable `score`. Allowed are 'category', 'month_only', and integers.",
+            "Invalid match type 'None' for variable `none`. Allowed are 'category', 'month_only', and integers.",
+        ]
+    }

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from osmatching.utils import MatchConfig, parse_and_validate_config
+
+
+CONFIG_DICT_DEFAULTS = {
+    "matches_per_case": 1,
+    "index_date_variable": "index_date",
+    "match_variables": {"age": 5},
+}
+
+
+def test_output_path():
+    test_data = {**CONFIG_DICT_DEFAULTS, "output_path": "test_output"}
+    config = MatchConfig(**test_data)
+    assert isinstance(config.output_path, str)
+
+    parse_and_validate_config(config)
+    assert isinstance(config.output_path, Path)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -71,3 +71,13 @@ def test_missing_required_vars(config_vars, error_keys):
     config = MatchConfig(**config_vars)
     config, errors = parse_and_validate_config(config)
     assert list(errors.keys()) == error_keys
+
+
+def test_replace_none_with_default():
+    config = get_match_config(
+        {"date_exclusion_variables": None, "closest_match_variables": None}
+    )
+    config, errors = parse_and_validate_config(config)
+    assert errors == {}
+    assert config.date_exclusion_variables == {}
+    assert config.closest_match_variables == []

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -34,10 +34,40 @@ def test_defaults():
     [
         (0, None),
         (1, None),
-        (2, ["min_matches_per_case (2) cannot be greater than matches_per_case (1)"]),
+        (
+            2,
+            [
+                "`min_matches_per_case` (2) cannot be greater than `matches_per_case` (1)"
+            ],
+        ),
     ],
 )
 def test_min_matches_per_case(min_matches, error):
     config = get_match_config({"min_matches_per_case": min_matches})
     config, errors = parse_and_validate_config(config)
     assert errors.get("min_matches_per_case") == error
+
+
+@pytest.mark.parametrize(
+    "config_vars,error_keys",
+    [
+        (
+            {
+                "matches_per_case": 1,
+            },
+            ["match_variables", "index_date_variable"],
+        ),
+        (
+            {
+                "index_date_variable": "index_date",
+                "match_variables": {"age": 5},
+            },
+            ["matches_per_case"],
+        ),
+        ({}, ["matches_per_case", "match_variables", "index_date_variable"]),
+    ],
+)
+def test_missing_required_vars(config_vars, error_keys):
+    config = MatchConfig(**config_vars)
+    config, errors = parse_and_validate_config(config)
+    assert list(errors.keys()) == error_keys


### PR DESCRIPTION
Previously, there was a bunch of validation of the provided config, but it was scattered throughout the matching calculations, which meant that we could do all the work of loading very large datasets and manipulating dataframes before it failed on a simple configuration error.

Once we move matching to a reusable action, it will be helpful to do the easy validation checks as early as possible.

This PR makes various updates to validate and populate defaults:
- pulls all config validation out of the calculation code, and validates when the command line arg is parsed (i.e. before any dataframes are loaded)
- captures all validation errors and reports them to the user, so if there are multiple errors, they can be fixed at the same time
- renames the confusingly named `replace_match_index_date_with_case` to `generate_match_index_date`
- parses the generate_match_index_date to a tuple for easier use in the calculations
- match datasets no longer need to include an index date column if the config specifies that we should generate one (it was previously assumed to be present, but then thrown away)
- Validates required columns on the input dataframes; there's additional validation that could be done on column types, but I'm leaving that for another time