### PR TITLE
fix: update the public module names

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,7 @@ Match COVID population to pneumonia population with:
  - greedy matching on age 
  - excluding patients who died or had various outcomes before their index date
 ```py
-from osmatching import match
-from osmatching.utils import load_dataframe, load_config
+from osmatching import load_config, load_dataframe, match
 
 match(
     case_df=load_dataframe("input_covid.csv.gz"),
@@ -280,8 +279,7 @@ Match COVID population to general population from 2019 with:
  - excluding patients who died or had various outcomes before their index date
  - case/match groups where there isn't at least one match are excluded
 ```py
-from osmatching import match
-from osmatching.utils import load_dataframe, load_config
+from osmatching import load_config, load_dataframe, match
 
 match(
     case_df=load_dataframe("input_covid.csv.gz"),
@@ -324,7 +322,7 @@ Match COVID population to general population from 2020 with:
  - greedy matching on age 
  - excluding patients who died or had various outcomes before their index date
 ```py
-from osmatching.utils import load_dataframe, load_config
+from osmatching import load_config, load_dataframe, match
 
 match(
     case_df=load_dataframe("input_covid.csv.gz"),

--- a/osmatching/__init__.py
+++ b/osmatching/__init__.py
@@ -1,4 +1,5 @@
 from osmatching.osmatching import match
+from osmatching.utils import load_config, load_dataframe
 
 
-__all__ = ["match"]
+__all__ = ["load_config", "load_dataframe", "match"]


### PR DESCRIPTION
Update the publicly exposed module names and fix the README accordingly.

I plan to do one last release before we move this repo and convert it to a reusable action. Currently the documentation in the README (on main) doesn't work with the latest released PyPI version, which a user has already encountered. Once we deprecate the package, I'll add a link in the README to the docs for the last PyPI release, but at that point it'll be more obvious that the version on main isn't intended for use as a locally installed package anymore.